### PR TITLE
Use /static route for seving static files

### DIFF
--- a/index.js
+++ b/index.js
@@ -65,6 +65,10 @@ app.get('/', (request, response) => response.sendFile('index.html', {
   maxAge: cacheTime
 }));
 
+app.get('/resume.pdf', (request, response) => {
+  response.redirect('/static/resume.pdf');
+});
+
 app.get('/db/carousel', cacheData(process.env.REDIS_CAROUSEL_KEY), async (request, response) => {
   try {
     let carousel = {};

--- a/index.js
+++ b/index.js
@@ -6,6 +6,7 @@ const Carousel = require('./models/carousel');
 const Portfolio = require('./models/portfolio');
 require('dotenv').config();
 const backendVersion = require('./package.json').version;
+const path = require('path');
 
 const app = express();
 const cacheTime = 4 * (1000 * 3600);
@@ -55,8 +56,9 @@ transporter.verify((error, success) => {
   }
 });
 
-app.use(express.json(), express.static('public'));
+app.use(express.json());
 app.use(cors());
+app.use('/static', express.static(path.join(__dirname, 'public')));
 
 app.get('/', (request, response) => response.sendFile('index.html', {
   root: path.join(__dirname, 'public'),

--- a/index.js
+++ b/index.js
@@ -65,6 +65,9 @@ app.get('/', (request, response) => response.sendFile('index.html', {
   maxAge: cacheTime
 }));
 
+/**
+ * Redirect for api.nextdev.in/resume.pdf so old links don't 404
+ */
 app.get('/resume.pdf', (request, response) => {
   response.redirect('/static/resume.pdf');
 });


### PR DESCRIPTION
https://api.nextdev.in/resume.pdf links should also now redirect to the correct /static route to ensure the old links don't 404